### PR TITLE
harden pipeline volumes and api error handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - uses: pre-commit/action@v3.0.0
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run lint
+        run: pre-commit run --all-files
       - name: Install dependencies
         run: pip install -r api/requirements.txt
       - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ perf-test:
 	bash scripts/perf_test.sh
 
 lint:
-	pre-commit run --all-files
+        pip install pre-commit
+        pre-commit run --all-files
 
 clean:
 	docker-compose -f mlflow/docker-compose.yml down

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,4 @@
-fastapi
-uvicorn[standard]
-mlflow
-scikit-learn
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+mlflow==2.11.1
+scikit-learn==1.4.1.post1

--- a/argo/templates/eval.yaml
+++ b/argo/templates/eval.yaml
@@ -18,3 +18,6 @@ spec:
         image: python:3.11-slim
         command: ["bash", "-c"]
         args: ["echo '{\"rmse\":0.0}' > /tmp/metrics.json"]
+        volumeMounts:
+          - name: workdir
+            mountPath: /scripts

--- a/argo/templates/prep.yaml
+++ b/argo/templates/prep.yaml
@@ -15,7 +15,10 @@ spec:
       container:
         image: python:3.11-slim
         command: ["bash", "-c"]
-        args: ["echo preprocessing {{inputs.parameters.dataset}} && cp /data/raw.csv /tmp/prepared.csv"]
+        args: ["echo preprocessing $DATASET && cp $DATASET /tmp/prepared.csv"]
+        env:
+          - name: DATASET
+            value: "{{inputs.parameters.dataset}}"
         volumeMounts:
           - name: workdir
             mountPath: /data

--- a/argo/templates/train.yaml
+++ b/argo/templates/train.yaml
@@ -20,3 +20,5 @@ spec:
         volumeMounts:
           - name: workdir
             mountPath: /scripts
+          - name: workdir
+            mountPath: /data

--- a/argo/workflow.yaml
+++ b/argo/workflow.yaml
@@ -4,6 +4,9 @@ metadata:
   generateName: mlops-
 spec:
   entrypoint: pipeline
+  volumes:
+    - name: workdir
+      emptyDir: {}
   arguments:
     parameters:
       - name: dataset

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -8,3 +8,47 @@ def test_predict_smoke():
     response = client.post("/predict", json={"features": [1, 2, 3]})
     assert response.status_code == 200
     assert "prediction" in response.json()
+
+
+def test_predict_missing_features():
+    client = TestClient(app)
+    response = client.post("/predict", json={})
+    assert response.status_code == 422
+
+
+def test_predict_wrong_type_features():
+    client = TestClient(app)
+    response = client.post("/predict", json={"features": "not_a_list"})
+    assert response.status_code == 422
+
+
+def test_predict_empty_features():
+    client = TestClient(app)
+    response = client.post("/predict", json={"features": []})
+    assert response.status_code == 422
+
+
+def test_predict_non_numeric_output(monkeypatch):
+    from api import app as api_app
+
+    class BadModel:
+        def predict(self, X):
+            return ["not_a_number"]
+
+    monkeypatch.setattr(api_app, "model", BadModel())
+    client = TestClient(app)
+    response = client.post("/predict", json={"features": [1, 2, 3]})
+    assert response.status_code == 500
+
+
+def test_predict_internal_error(monkeypatch):
+    from api import app as api_app
+
+    class ErrorModel:
+        def predict(self, X):
+            raise Exception("boom")
+
+    monkeypatch.setattr(api_app, "model", ErrorModel())
+    client = TestClient(app)
+    response = client.post("/predict", json={"features": [1, 2, 3]})
+    assert response.status_code == 500


### PR DESCRIPTION
## Summary
- add logging and stricter error handling to prediction API
- mount shared workdir volume in Argo templates and use dataset env var
- pin API dependencies and extend smoke tests for error cases

## Testing
- `pre-commit run --files .github/workflows/ci.yaml Makefile api/app.py api/requirements.txt argo/templates/eval.yaml argo/templates/prep.yaml argo/templates/train.yaml argo/workflow.yaml tests/test_api_smoke.py` *(fails: command not found)*
- `pip install -r api/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_689906906f60832384337a62b3ad0a6d

## Summary by Sourcery

Harden the prediction API by adding stricter input validation, error handling, and logging; pin dependencies; extend smoke tests; and mount a shared workdir volume across Argo pipeline tasks

Bug Fixes:
- Return 422 for missing or invalid prediction inputs and 500 for non-numeric or failed predictions
- Log exceptions during model loading from MLflow

Enhancements:
- Enforce non-empty feature lists using Pydantic conlist in the prediction schema
- Pin API dependencies to exact versions in requirements.txt
- Use a shared workdir volume and DATASET environment variable in Argo pipeline templates

CI:
- Install and run pre-commit linter in CI workflow and Makefile

Deployment:
- Declare an emptyDir workdir volume in the Argo workflow and mount it in prep, eval, and train templates

Tests:
- Add smoke tests for missing features, wrong types, empty lists, non-numeric predictions, and internal model errors