### PR TITLE
Refactor train-local target and sanitize prediction errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,7 @@ up-mlflow:
 	docker-compose -f mlflow/docker-compose.yml up -d
 
 train-local:
-	python - <<'PY2'\
-import mlflow\
-import numpy as np\
-from sklearn.linear_model import LinearRegression\
-X = np.arange(0,10).reshape(-1,1)\
-y = np.arange(0,10)\
-model = LinearRegression().fit(X, y)\
-with mlflow.start_run():\
-    mlflow.sklearn.log_model(model, 'model')\
-    mlflow.log_metric('rmse', 0.0)\
-PY2
+	python scripts/train.py
 
 argo-submit:
 	argo submit argo/workflow.yaml

--- a/api/app.py
+++ b/api/app.py
@@ -64,5 +64,6 @@ def predict(data: Features) -> dict[str, float]:
     except (ValueError, TypeError):
         raise HTTPException(status_code=500, detail="Prediction output is not numeric")
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.exception("Prediction failed: %s", e)
+        raise HTTPException(status_code=500, detail="Prediction failed")
     return {"prediction": pred}

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,4 +2,4 @@ fastapi==0.110.0
 uvicorn[standard]==0.29.0
 mlflow==2.11.1
 scikit-learn==1.4.1.post1
-httpx==0.27.0
+httpx>=0.25,<0.27

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -59,5 +59,4 @@ def test_predict_internal_error(monkeypatch):
     client = TestClient(app)
     response = client.post("/predict", json={"features": [1, 2, 3]})
     assert response.status_code == 500
-    data = response.json()
-    assert "boom" in data.get("detail", "")
+    assert response.json()["detail"] == "Prediction failed"


### PR DESCRIPTION
## Summary
- replace inline Python in Makefile with call to training script
- sanitize prediction errors and return generic message
- relax httpx requirement and align test expectations

## Testing
- `pip install -r api/requirements.txt` *(fails: Could not find a version that satisfies the requirement httpx<0.27,>=0.25)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'api')*

------
https://chatgpt.com/codex/tasks/task_e_68990b692f68832396dd62177e1aa912

## Summary by Sourcery

Refactor local training command, sanitize prediction errors, relax httpx constraint, and align tests with new error handling

Bug Fixes:
- Log and mask internal exception messages in the prediction endpoint by returning a generic error

Enhancements:
- Refactor Makefile "train-local" target to call the training script
- Relax httpx dependency to >=0.25,<0.27

Tests:
- Update smoke test to assert the generic "Prediction failed" message instead of raw exception detail